### PR TITLE
polkit: restrict access

### DIFF
--- a/data/pkit-10-gromox.rules
+++ b/data/pkit-10-gromox.rules
@@ -1,8 +1,41 @@
 polkit.addRule(function(action, subject) {
-	if ((action.id == "org.freedesktop.systemd1.manage-units" ||
-	    action.id == "org.freedesktop.systemd1.manage-unit-files" ||
-	    action.id == "org.freedesktop.systemd1.reload-daemon") &&
-	    subject.user == "grommunio") {
+	const services = [
+		"grommunio-admin-api.service",
+		"grommunio-admin-api.socket",
+		"grommunio-antispam.service",
+		"grommunio-cui@tty1.service",
+		"grommunio-fetchmail.timer",
+		"grommunio-index.timer",
+		"gromox-delivery-queue.service",
+		"gromox-delivery.service",
+		"gromox-event.service",
+		"gromox-http.service",
+		"gromox-imap.service",
+		"gromox-midb.service",
+		"gromox-pop3.service",
+		"gromox-timer.service",
+		"gromox-zcore.service",
+		"nginx.service",
+		"php-fpm.service",
+		"postfix.service",
+		"redis@grommunio.service"
+	];
+	if (
+		(
+			(
+				action.id == "org.freedesktop.systemd1.manage-units" 
+				||
+				action.id == "org.freedesktop.systemd1.manage-unit-files" 
+				||
+				action.id == "org.freedesktop.systemd1.reload-daemon"
+			) 
+			&& 
+			subject.user == "grommunio" 
+			&&
+			services.includes(action.lookup("unit")) == true
+		)
+	)
+	{
 		return polkit.Result.YES;
 	}
 });


### PR DESCRIPTION
As i was fiddling around with polkit I took a peek into my Testsystem and saw this rule. Maybe it would be a good idea to make the proposed or similar changes?

I just thought if someday some vulnerability opens up it wouldn't be such a big target with only allowing stuff like "stopping postfix" instead of complete shutdown or even worse?


My local Notes not worthwhile the Commit.. `head -n4 pkit-10-gromox.rules`
```
// Use a constant List of unit-names instead of allowing just *everything* on the System.
// The Array can be created with the following command:
// systemctl list-units --output json-pretty |jq -s  '[ .[]|sort_by(.unit)[]|select(.unit | test("^grom*|redis@|postfix|nginx|php"))|.unit ]'
// Just for show - Pipe "|" the result to the following command: jq '.[]|test("^grom")'
```

These rules could even be way more granular. It's a bit of work but this shouldn't happen that often. ... oo00 ( There are more typo's to fix than maintaining these Policy's :rofl: ..)

PS: the `sudo`-calls for postfix reload/restart could also be removed if i'm not mistaken?!