### PR TITLE
spec: add missing type to getDashboard operation

### DIFF
--- a/res/openapi.yaml
+++ b/res/openapi.yaml
@@ -390,6 +390,7 @@ paths:
                         type: integer
                       available:
                         description: Memory that is available for applications (bytes)
+                        type: integer
                   swap:
                     description: Swap statistics
                     type: object


### PR DESCRIPTION
We were missing a type specification for the RAM statistics in the 200 response of the `getDashboard` request: available memory is also given as an integer.