### PR TITLE
data/polkit-10-grommunio.rules: fix rule

### DIFF
--- a/data/polkit-10-grommunio.rules
+++ b/data/polkit-10-grommunio.rules
@@ -26,7 +26,7 @@ polkit.addRule(function(action, subject) {
 				(
 					action.id == "org.freedesktop.systemd1.manage-units"
 					&&
-					services.includes(action.lookup("unit")) == true
+					action.lookup("unit").toLowerCase().includes(".service")
 				)
 				||
 				action.id == "org.freedesktop.systemd1.manage-unit-files"


### PR DESCRIPTION
yeah somehow that isn't working what i fabricated back then..
this should do afaict

fyi, debugging that stuff is extremly irritating especially with polkitd 121/122 but with 126 it get's better as it now has a logging switch \ö/
```
 -l, --log-level=[emerg|alert|crit|err|warning|notice|info|debug]     Set a level of logging (syslog style). Defaults to 'notice'.
```