### PR TITLE
systemd/grommunio-admin-api.service

### DIFF
--- a/data/grommunio-admin-api.service
+++ b/data/grommunio-admin-api.service
@@ -1,11 +1,9 @@
 [Unit]
 Description=grommunio admin api
-After=grommunio-admin-api.socket
-Requires=grommunio-admin-api.socket
 
 [Service]
-WorkingDirectory=/usr/share/grommunio-admin-api/
-ExecStart=/usr/sbin/uwsgi --ini /usr/share/grommunio-admin-api/api-config.ini
+WorkingDirectory=/usr/share/grommunio-admin-api
+ExecStart=/usr/sbin/uwsgi --ini api-config.ini
 User=grommunio
 Group=nginx
 SupplementaryGroups=grommunio


### PR DESCRIPTION
 * remove useless requires+after to the same named socket. a .socket will automatically trigger a service if something want to talk to it. you will only ever need to enable the .socket and don't have to explicitly enable the .service in such a scenario. stichwort: triggering units
 * add after=mysql.service to not get any silly database errors anymore during boot because the database isn't accessible in the first try. the alias mysql.service was chosen to have a broader compatibility for anyone who isn't using mariadb.


[triggering units?](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#:~:text=Note%3A%20Triggers%3D%20is%20created%20implicitly%20between%20a%20socket%2C%20path%20unit%2C)