### PR TITLE
/api/v1/system/logs: Support binary-data in journal-entries.

### DIFF
--- a/tools/logs.py
+++ b/tools/logs.py
@@ -76,8 +76,11 @@ class JournaldReader:
 
     @staticmethod
     def _entry(data):
+        msg = data.get("MESSAGE", "")
+        if isinstance(msg, (bytes, bytearray)):
+             msg = msg.decode("utf-8", "ignore")
         return dict(level=data["PRIORITY"],
-                    message=data["MESSAGE"],
+                    message=msg,
                     time=data["__REALTIME_TIMESTAMP"].strftime("%Y-%m-%d %H:%M:%S.%f"),
                     runtime=data["__MONOTONIC_TIMESTAMP"].timestamp.total_seconds())
 


### PR DESCRIPTION
Attempt UTF-8-encoding or (ignore unprintable) for binary-logdata (BLOB).
journalctl masks binary log data as [xxxB blob data]:
`Nov 25 13:56:00 localhost  imap[2795947]: [53B blob data]`

This patch attempts to encode logged binary-data in UTF-8 and makes it displayable using `decode("UTF-8", "ignore").` In my opinion, this increases information density in cases where binary data still contain readable text:
`[2025-11-25 13:56:00.201637]: [::ffff:xxx.xxx.xxx.xxx]:20648  <  A	+|N 8րK
];>F^: ret=0h code=0`

Fixes #56 