### PR TITLE
Load and register requests_unixsocket if it is available

### DIFF
--- a/endpoints/system/misc.py
+++ b/endpoints/system/misc.py
@@ -199,7 +199,7 @@ def rspamdProxy(path):
     if path not in conf["antispamEndpoints"]:
         return jsonify(message="Endpoint not allowed"), 403
     try:
-        res = requests.get(conf["antispamUrl"]+"/"+path, request.args, stream=True)
+        res = requests.get(conf["antispamUrl"]+"/"+path, params=request.args, stream=True)
     except BaseException as err:
         API.logger.error(type(err).__name__+": "+" - ".join(str(arg) for arg in err.args))
         return jsonify(message="Failed to connect to antispam"), 503

--- a/main.py
+++ b/main.py
@@ -9,6 +9,14 @@ Can be used to run the API in stand-alone mode by directly executing the file or
 in combination with a WSGI server using the API object as callable
 """
 
+# If it is available, load requests_unixsocket and register it globally.
+# This allows e.g. antispamUrl: http+unix://%2Frun%2Frspamd%2Fcontroller.sock
+try:
+    import requests_unixsocket
+    requests_unixsocket.monkeypatch()
+except Exception:
+    pass
+
 if __name__ == '__main__':
     import os
     import sys


### PR DESCRIPTION
This allows talking to rspamd (and probably other backends) over a UNIX socket instead of requiring a TCP socket, e.g.

options:
    antispamUrl: "http+unix://%2Frun%2Frspamd%2Fcontroller.sock"

The change in endpoints/system/misc.py is needed because requests_unixsocket (at least the current version, 0.4.1) implements only the version of "get" with one positional argument.