### PR TITLE
Fix unwanted escaping of regex string-constants (SyntaxWarning: invalid escape sequence)

### DIFF
--- a/cli/common.py
+++ b/cli/common.py
@@ -21,7 +21,7 @@ def userFilter(userSpec, autocompleting, *filters):
     from sqlalchemy import and_
     return and_(True if userSpec is None else
                 Users.ID == userSpec if userSpec.isdigit() else
-                Users.username.ilike(userSpec.replace("_", "\_")+("%" if autocompleting else "")), *filters)
+                Users.username.ilike(userSpec.replace("_", r"\_")+("%" if autocompleting else "")), *filters)
 
 
 def userCandidates(userSpec, *filters):

--- a/endpoints/__init__.py
+++ b/endpoints/__init__.py
@@ -385,7 +385,7 @@ def userQuery(domainID=None):
         expr = request.args["match"]
         fields = set(request.args["matchFields"].split(",")) if "matchFields" in request.args else None
         isUnicode = any(ord(c) > 127 for c in expr)
-        matchexpr = tuple("%"+substr.replace("_", "\_")+"%" for substr in expr.split())
+        matchexpr = tuple("%"+substr.replace("_", r"\_")+"%" for substr in expr.split())
         matchables = Users._meta.matchables if fields is None else (m for m in Users._meta.matchables if m.alias in fields)
         targets = []
         for prop in matchables:

--- a/tools/DataModel.py
+++ b/tools/DataModel.py
@@ -577,7 +577,7 @@ class DataModel:
         """Add fuzzy matching to query."""
         cls._init()
         isUnicode = any(ord(c) > 127 for c in expr)
-        matchexpr = tuple("%"+substr.replace("_", "\_")+"%" for substr in expr.split())
+        matchexpr = tuple("%"+substr.replace("_", r"\_")+"%" for substr in expr.split())
         matchables = cls._meta.matchables if fields is None else (m for m in cls._meta.matchables if m.alias in fields)
         targets = []
         for prop in matchables:


### PR DESCRIPTION
Regex-constants like `"\_"` should not be escaped - assign them as raw-string literals.
`"\_" `->` r"\_"`
Fixes commit a01501e causing 
`endpoints/__init__.py:388: SyntaxWarning: invalid escape sequence '\_'`
and related.